### PR TITLE
Tighten Thursday breaks so panel ends at 6pm (preview)

### DIFF
--- a/src/schedule-preview/index.html
+++ b/src/schedule-preview/index.html
@@ -1248,36 +1248,36 @@ const SCHEDULE = {
     rooms: ROOMS_THU,
     rows: [
       { type: "plenary", time: "9:00 - 9:30", title: "Design Plunge Kickoff", note: "THE EXPERT and THE CHALLENGE" },
-      { type: "break", time: "9:30 - 10:00", title: "Coffee break" },
+      { type: "break", time: "9:30 - 9:45", title: "Coffee break" },
 
-      { type: "block-header", label: "Block 1", time: "10:00 - 12:00" },
+      { type: "block-header", label: "Block 1", time: "9:45 - 11:45" },
       {
         type: "block",
         slots: [
-          { type: "talks", time: ["10:00", "11:00"], sessionIds: ["1189215", "1188610"] },
-          { type: "talks", time: ["10:00", "11:00"], sessionIds: ["1117537", "1189426"] },
+          { type: "talks", time: ["9:45", "10:45"], sessionIds: ["1189215", "1188610"] },
+          { type: "talks", time: ["9:45", "10:45"], sessionIds: ["1117537", "1189426"] },
           { sessionId: "1202756" },
           { sessionId: "1189257" },
           { sessionId: "1142871" }
         ]
       },
 
-      { type: "break", time: "12:00 - 1:00", title: "Lunch" },
+      { type: "break", time: "11:45 - 12:45", title: "Lunch" },
 
-      { type: "block-header", label: "Block 2", time: "1:00 - 3:00" },
+      { type: "block-header", label: "Block 2", time: "12:45 - 2:45" },
       {
         type: "block",
         slots: [
-          { type: "talks", time: ["1:00", "2:00"], sessionIds: ["1129252", "1189435"] },
-          { type: "talks25", time: ["1:00", "1:30", "2:00", "2:30"], sessionIds: ["TBD-evans-interp", "1187527", "1189152", "1185200"], note: "4 × 25-min" },
+          { type: "talks", time: ["12:45", "1:45"], sessionIds: ["1129252", "1189435"] },
+          { type: "talks25", time: ["12:45", "1:15", "1:45", "2:15"], sessionIds: ["TBD-evans-interp", "1187527", "1189152", "1185200"], note: "4 × 25-min" },
           { sessionId: "1184524" },
           { sessionId: "TBD-indu-legacy" },
           { sessionId: "1185110" }
         ]
       },
 
-      { type: "break", time: "3:00 - 3:30", title: "Break" },
-      { type: "block-header", label: "Design Plunge: Working Session 1", time: "3:30 - 5:30" },
+      { type: "break", time: "2:45 - 3:00", title: "Break" },
+      { type: "block-header", label: "Design Plunge: Working Session 1", time: "3:00 - 5:00" },
       {
         type: "block",
         columns: COHORTS,
@@ -1289,9 +1289,9 @@ const SCHEDULE = {
           { type: "cohort", label: "Form teams, frame the challenge, begin discovery" }
         ]
       },
-      { type: "break", time: "5:30 - 5:45", title: "Break" },
-      { type: "session-row", time: "5:45 - 6:30", room: null, sessionId: "TBD-panel", isPlenary: true },
-      { type: "break", time: "6:30", title: "Drinks / social" }
+      { type: "break", time: "5:00 - 5:15", title: "Break" },
+      { type: "session-row", time: "5:15 - 6:00", room: null, sessionId: "TBD-panel", isPlenary: true },
+      { type: "break", time: "6:00", title: "Drinks / social" }
     ]
   },
   fri: {


### PR DESCRIPTION
Shortens coffee/afternoon/transition breaks from 30/30/15 to 15/15/15 (saves 30 min). Lunch stays at 60. All session and block lengths unchanged. Panel now runs 5:15-6:00 with drinks at 6:00. Live at https://exploreddd.com/schedule-preview/ after merge.